### PR TITLE
Add error message if input is empty or is a duplicate of existing item

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,7 +58,10 @@ export function App() {
 						path="/list"
 						element={<List data={data} listToken={listToken} />}
 					/>
-					<Route path="/add-item" element={<AddItem listId={listToken} />} />
+					<Route
+						path="/add-item"
+						element={<AddItem listId={listToken} data={data} />}
+					/>
 				</Route>
 			</Routes>
 		</Router>

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -4,7 +4,7 @@ import { Navigate } from 'react-router-dom';
 
 import './AddItem.css';
 
-export function AddItem({ listId }) {
+export function AddItem({ listId, data }) {
 	const [itemToAdd, setItemToAdd] = useState({
 		itemName: '',
 		buyingFrequency: 7,
@@ -15,8 +15,51 @@ export function AddItem({ listId }) {
 		return <Navigate to="/" />;
 	}
 
+	const isWhiteSpace = (char) => {
+		return ' \t\n'.includes(char);
+	};
+
+	const isPunctuation = (char) => {
+		return ';:.,?!-\'"(){}'.includes(char);
+	};
+
+	const normalize = (string) => {
+		return string
+			.trim()
+			.toLowerCase()
+			.split('')
+			.filter((char) => !isPunctuation(char) && !isWhiteSpace(char))
+			.join('');
+	};
+
 	const handleSubmit = async (e) => {
 		e.preventDefault();
+
+		if (itemToAdd.itemName.length === 0) {
+			setMessage('Please enter an item.');
+
+			setTimeout(() => {
+				setMessage('');
+			}, 5000);
+
+			return;
+		}
+
+		const comparedItems = data.filter(
+			(item) => normalize(item.name) === normalize(itemToAdd.itemName),
+		);
+
+		if (comparedItems.length > 0) {
+			setMessage('This item is already in your list.');
+
+			setItemToAdd({ itemName: '', buyingFrequency: 7 });
+
+			setTimeout(() => {
+				setMessage('');
+			}, 5000);
+
+			return;
+		}
 
 		try {
 			const docRef = await addItem(listId, {


### PR DESCRIPTION


## Description
This code added the functionality that users shouldn't be able to add an empty item to their list, or add the same item twice. If they try to do this,  an error message that explains the problem will be shown to them. This way, we prevented some clutter in their lists. 

## Related Issue

Closes #9 

## Acceptance Criteria
 
- [x] Show an error message if the user tries to submit an empty item

- [x]  Show an error message if the user tries to submit a new item that is identical to an existing name. For instance, if the list contains apples and the user adds apples.

- [x] Show an error message if the user tries to submit a new item that matches an existing name with punctuation and casing normalized. For instance, if the list contains apples and the user adds aPples or apples, or apples.

- [x]  The user’s original input is saved in the database

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Prompt that item is saved to database

![itemsavedtodatabase](https://user-images.githubusercontent.com/78281826/235720495-525cc732-dd6a-47f7-9472-b3e45b4e61c6.png)




### Prompt that item already exist


![item already exist](https://user-images.githubusercontent.com/78281826/235720664-1ea9b0ac-01e6-4b0e-a567-3c3a429d926c.png)


## Testing Steps / QA Criteria

- From your terminal, pull down this branch with git pull ps-am-alert-empty-or-existing-item and check  that branch out with git checkout ps-am-alert-empty-or-existing-item.
- Then npm start to launch the app
- Navigate to Add item and add an item
