### PR TITLE
Compute dateNextPurchase and record in the database

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -7,7 +7,8 @@ import {
 } from 'firebase/firestore';
 import { addDoc } from 'firebase/firestore';
 import { db } from './config';
-import { getFutureDate } from '../utils';
+import { getFutureDate, getDaysBetweenDates } from '../utils';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 /**
  * Subscribe to changes on a specific list in the Firestore database (listId), and run a callback (handleSuccess) every time a change happens.
@@ -75,12 +76,21 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 	return docRef;
 }
 
-export async function updateItem(listId, documentId, totalPurchases) {
+export async function updateItem(
+	listId,
+	documentId,
+	totalPurchases,
+	dateLastPurchased,
+) {
 	const itemRef = doc(db, listId, documentId);
+
+	const getDays = getDaysBetweenDates(Date.now(), dateLastPurchased);
+	const estimate = calculateEstimate(4, getDays, totalPurchases);
 
 	const updatedDocRef = await updateDoc(itemRef, {
 		dateLastPurchased: new Date(),
 		totalPurchases: ++totalPurchases,
+		dateNextPurchased: getFutureDate(estimate),
 	});
 
 	return updatedDocRef;

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -1,10 +1,4 @@
-import {
-	collection,
-	onSnapshot,
-	doc,
-	updateDoc,
-	serverTimestamp,
-} from 'firebase/firestore';
+import { collection, onSnapshot, doc, updateDoc } from 'firebase/firestore';
 import { addDoc } from 'firebase/firestore';
 import { db } from './config';
 import { getFutureDate, getDaysBetweenDates } from '../utils';

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -81,11 +81,29 @@ export async function updateItem(
 	documentId,
 	totalPurchases,
 	dateLastPurchased,
+	dateNextPurchased,
+	dateCreated,
 ) {
 	const itemRef = doc(db, listId, documentId);
+	const dateLastPurchasedInMs = dateLastPurchased
+		? dateLastPurchased.toDate()
+		: dateCreated.toDate();
 
-	const getDays = getDaysBetweenDates(Date.now(), dateLastPurchased);
-	const estimate = calculateEstimate(4, getDays, totalPurchases);
+	const getDaysBetweenLastPurchase = getDaysBetweenDates(
+		Date.now(),
+		dateLastPurchasedInMs,
+	);
+
+	const getDaysBetweenNextPurchase = getDaysBetweenDates(
+		dateNextPurchased.toDate(),
+		dateLastPurchasedInMs,
+	);
+
+	const estimate = calculateEstimate(
+		getDaysBetweenNextPurchase,
+		getDaysBetweenLastPurchase,
+		totalPurchases,
+	);
 
 	const updatedDocRef = await updateDoc(itemRef, {
 		dateLastPurchased: new Date(),

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -21,8 +21,7 @@ export function ListItem({ item, listToken }) {
 		}
 	};
 	const trial = dateLastPurchased.toDate();
-	console.log(trial.getTime());
-	console.log(getDaysBetweenDates(trial));
+	console.log(name, getDaysBetweenDates(Date.now(), trial));
 
 	useEffect(() => {
 		if (dateLastPurchased == null) return;

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { updateItem } from '../api/firebase';
+import { getDaysBetweenDates } from '../utils';
 import './ListItem.css';
 
 export function ListItem({ item, listToken }) {
@@ -19,6 +20,9 @@ export function ListItem({ item, listToken }) {
 			}
 		}
 	};
+	const trial = dateLastPurchased.toDate();
+	console.log(trial.getTime());
+	console.log(getDaysBetweenDates(trial));
 
 	useEffect(() => {
 		if (dateLastPurchased == null) return;

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { updateItem } from '../api/firebase';
-import { getDaysBetweenDates } from '../utils';
+
 import './ListItem.css';
 
 export function ListItem({ item, listToken }) {
@@ -13,15 +13,18 @@ export function ListItem({ item, listToken }) {
 
 		if (checked) {
 			try {
-				await updateItem(listToken, id, totalPurchases);
+				await updateItem(
+					listToken,
+					id,
+					totalPurchases,
+					dateLastPurchased.toDate(),
+				);
 				console.log('Shopping item successfully updated');
 			} catch (error) {
 				console.log(error);
 			}
 		}
 	};
-	const trial = dateLastPurchased.toDate();
-	console.log(name, getDaysBetweenDates(Date.now(), trial));
 
 	useEffect(() => {
 		if (dateLastPurchased == null) return;

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,7 +1,5 @@
 import { useEffect, useState } from 'react';
 import { updateItem } from '../api/firebase';
-import { getDaysBetweenDates, getFutureDate } from '../utils';
-import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 import './ListItem.css';
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,12 +1,21 @@
 import { useEffect, useState } from 'react';
 import { updateItem } from '../api/firebase';
+import { getDaysBetweenDates, getFutureDate } from '../utils';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 import './ListItem.css';
 
 export function ListItem({ item, listToken }) {
 	const [isChecked, setIsChecked] = useState(false);
 
-	const { name, id, totalPurchases, dateLastPurchased } = item;
+	const {
+		name,
+		id,
+		totalPurchases,
+		dateLastPurchased,
+		dateNextPurchased,
+		dateCreated,
+	} = item;
 
 	const handleChange = async (e) => {
 		const { checked } = e.target;
@@ -17,7 +26,9 @@ export function ListItem({ item, listToken }) {
 					listToken,
 					id,
 					totalPurchases,
-					dateLastPurchased.toDate(),
+					dateLastPurchased,
+					dateNextPurchased,
+					dateCreated,
 				);
 				console.log('Shopping item successfully updated');
 			} catch (error) {

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -11,8 +11,6 @@ export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
 
-export function getDaysBetweenDates(currentDate, dateLastPurchased) {
-	return Math.round(
-		(currentDate - dateLastPurchased) / ONE_DAY_IN_MILLISECONDS,
-	);
+export function getDaysBetweenDates(startDate, endDate) {
+	return Math.round((startDate - endDate) / ONE_DAY_IN_MILLISECONDS);
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,7 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+
+export function getDaysBetweenDates(dateLastPurchase) {
+	return new Date((Date.now() - dateLastPurchase) / ONE_DAY_IN_MILLISECONDS);
+}

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -11,6 +11,8 @@ export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
 
-export function getDaysBetweenDates(dateLastPurchase) {
-	return new Date((Date.now() - dateLastPurchase) / ONE_DAY_IN_MILLISECONDS);
+export function getDaysBetweenDates(currentDate, dateLastPurchased) {
+	return Math.round(
+		(currentDate - dateLastPurchased) / ONE_DAY_IN_MILLISECONDS,
+	);
 }


### PR DESCRIPTION
## Description

This code calculates the estimate of `dateNextpurchase` when a user clicks on the checkbox (indicating user has bought the item). It updates the existing document in firebase to have a new value for next purchase date which was calculated using the `calculateEstimate` function from the `@the-collab-lab/shopping-list-utils` module. It takes in the `previousEstimate`, `daysSinceLastPurchase` and `totalPurchase` and returns a number indicating the number of days. This number is passed to the `getFutureDates` function to  return a date value.

## Related Issue

closes #10 

## Acceptance Criteria

- [x] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
 - [x] `dateNextPurchased` is saved as a date, not a number
- [x] A `getDaysBetweenDates` function is exported from utils/dates.js and imported into api/firebase.js
 - [x] This function takes two JavaScript Dates and return the number of days that have passed between them

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


## Testing Steps / QA Criteria

-  Check the firebase console to check what the value of dateNextPurchase is
- In the List page, click on a list item to mark it as purchase, if list item is empty add items to your list first then go back to step 1
- Check the firebase console again to see the new computed dateNextPurchase value

